### PR TITLE
Bug fixes

### DIFF
--- a/src/frontend/src/pages/analytical-page/components/RcsbSaguaro.tsx
+++ b/src/frontend/src/pages/analytical-page/components/RcsbSaguaro.tsx
@@ -200,7 +200,7 @@ const RcsbSaguaro = forwardRef(({
                 }
                 if (d.label) {
                     const positionData: RcsbPositionData = JSON.parse(d.label);
-                    if (positionData.position) {
+                    if (positionData.position !== undefined) {
                         tooltipHtml += `<strong>Position:</strong> ${positionData.position}`;
                     }
                     if (positionData.residue) {
@@ -209,13 +209,13 @@ const RcsbSaguaro = forwardRef(({
                     if (squashBindingSites && positionData.bindingSiteId) {
                         tooltipHtml += ` | <strong>Name:</strong> ${toBindingSiteLabel(positionData.bindingSiteId)}`;
                     }
-                    if (positionData.confidence) {
+                    if (positionData.confidence !== undefined) {
                         tooltipHtml += ` | <strong>Probability:</strong> ${positionData.confidence.toFixed(2)}`;
                     }
                     if (positionData.dataSourceName) {
                         tooltipHtml += ` | <strong>Source:</strong> ${dataSourceDisplayNames[positionData.dataSourceName]}`;
                     }
-                    if (positionData.conservationValue) {
+                    if (positionData.conservationValue !== undefined) {
                         tooltipHtml += ` | <strong>Value:</strong> ${positionData.conservationValue.toFixed(2)}`;
                     }
                 }


### PR DESCRIPTION
- Polling sa zapínal po príchode užívateľa na analytickú stránku (mal sa zapnúť až po prvotnej snahe fetchnutia dát).
- Po príchode na analytickú stránku sa (asi občas aj na produkcii, ale hlavne) pri vývoji na localhostovi zbytočne objavil toast s varovaním, že chainy sa nefetchli, že skúša znova (alebo tak nejak...), pretože client žiadal o súbor s chainami skôr, než ho server stihol vytvoriť (zbytočne, lebo krátku chvíľu na to sa vytvoril a pri retry fetchol).
- Nulové hodnoty sa nezobrazovali v tooltipe, napr. namiesto *Position: 0 | T* bolo len *| T*.

Vyššie uvedené chyby boli opravené.